### PR TITLE
Potential fix for code scanning alert no. 3: Flask app is run in debug mode

### DIFF
--- a/rpi-door/door.py
+++ b/rpi-door/door.py
@@ -5,6 +5,7 @@ from signal import SIGTERM, signal
 import threading
 import time
 from datetime import datetime
+import os
 
 app = Flask(__name__)
 CORS(app)
@@ -84,7 +85,8 @@ def door_last_changed():
         return jsonify({"last_changed": "Not set yet"})
 
 def start_flask_app():
-    app.run(host='0.0.0.0', port=5000, debug=True, use_reloader=False)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(host='0.0.0.0', port=5000, debug=debug_mode, use_reloader=False)
 
 if __name__ == '__main__':
     # Start the door monitor in a background thread


### PR DESCRIPTION
Potential fix for [https://github.com/tildeeine/home_safety_iot/security/code-scanning/3](https://github.com/tildeeine/home_safety_iot/security/code-scanning/3)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is to control the `debug` parameter based on an environment variable or a configuration setting. This way, we can easily switch between development and production modes without changing the code.

1. Import the `os` module to read environment variables.
2. Modify the `start_flask_app` function to set the `debug` parameter based on an environment variable (e.g., `FLASK_DEBUG`).
3. Update the `app.run` call to use the `debug` parameter based on the environment variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
